### PR TITLE
use base workshop image as recommended by docs

### DIFF
--- a/workshop-resources/workshop-deploy.yaml
+++ b/workshop-resources/workshop-deploy.yaml
@@ -13,7 +13,7 @@ spec:
   content:
     # Use the default image, one of the pre-existing ones, or you can build your own
     # https://docs.edukates.io/en/develop/runtime-environment/workshop-definition.html#container-image-for-the-workshop
-    image: quay.io/eduk8s/jdk11-environment:latest
+    image: jdk11-environment:*
     files: http://files.$(workshop_namespace).svc.cluster.local/workshop.tar.gz
   session:
     applications:


### PR DESCRIPTION
use base workshop image as recommended by docs that avoids hardcoded registry and matches to version of Educates deployed.